### PR TITLE
Modify ports to bind to localhost only

### DIFF
--- a/aurad-cli/src/containers/docker/docker-compose.yml
+++ b/aurad-cli/src/containers/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
             
 services:
     parity:
-        image: parity/parity:v2.2.7
+        image: parity/parity:v2.2.9
         env_file: aurad_config.env
         volumes:
             - type: bind
@@ -10,7 +10,7 @@ services:
               target: /eth
         command: ["--light", "--on-demand-retry-count=100", "--jsonrpc-interface=all", "--base-path", "/eth"]
         ports:
-            - "8545:8545"
+            - "127.0.0.1:8545:8545"
             - "8546:8546"
             - "30303:30303"
             - "30303:30303/udp"
@@ -26,7 +26,7 @@ services:
         stop_signal: SIGINT
         stop_grace_period: 20s
         ports:
-            - "33006:3306"
+            - "127.0.0.1:33006:3306"
     aurad:
         image: auroradao/aurad:0.1.2
         depends_on:


### PR DESCRIPTION
For containers that don't require  exposing ports to public

Update parity image version to 2.2.9